### PR TITLE
Change how to handle output.

### DIFF
--- a/prolog/builtins.py
+++ b/prolog/builtins.py
@@ -30,9 +30,9 @@ class Write:
         ))
         return result
 
-    def display(self):
+    def display(self, stream_writer):
         for arg in self.args:
-            print(arg, end='')
+            stream_writer(str(arg))
 
     def __str__(self):
         if len(self.args) == 0:
@@ -54,8 +54,8 @@ class Nl:
     def substitute(self, bindings):
         return Nl()
 
-    def display(self):
-        print('')
+    def display(self, stream_writer):
+        stream_writer('\n')
 
     def __str__(self):
         return 'nl'
@@ -74,8 +74,8 @@ class Tab:
     def substitute(self, bindings):
         return Tab()
 
-    def display(self):
-        print('', end='\t')
+    def display(self, stream_writer):
+        stream_writer('\t')
 
     def __str__(self):
         return 'nl'

--- a/prolog/interpreter.py
+++ b/prolog/interpreter.py
@@ -1,5 +1,5 @@
 from .types import Variable, Term, merge_bindings, Arithmetic, Logic, FALSE
-from .builtins import Write, Nl, Tab
+from .builtins import Write, Nl, Tab, Fail
 
 
 class Rule:
@@ -25,13 +25,20 @@ class Conjunction(Term):
             return True
         return False
 
+    def _is_fail(self, arg):
+        if isinstance(arg, Fail):
+            return True
+        return False
+
     def query(self, runtime):
         def solutions(index, bindings):
             if index >= len(self.args):
                 yield self.substitute(bindings)
             else:
                 arg = self.args[index]
-                if self._is_builtin(arg):
+                if self._is_fail(arg):
+                    yield FALSE()
+                elif self._is_builtin(arg):
                     arg.substitute(bindings).display()
                     yield from solutions(index + 1, bindings)
                 elif isinstance(arg, Arithmetic):
@@ -90,6 +97,8 @@ class Runtime:
                     for item in body.query(self):
                         if not isinstance(item, FALSE):
                             yield head.substitute(body.match(item))
+                        elif isinstance(item, FALSE):
+                            yield None
 
     def execute(self, query):
         goal = query

--- a/prolog/repl.py
+++ b/prolog/repl.py
@@ -84,7 +84,9 @@ def run_repl(runtime):
                 is_first_iter = False
                 has_solution = False
                 for solution in runtime.execute(goal):
-                    has_solution = True
+                    print(f'sol: {solution}')
+                    if solution is not None:
+                        has_solution = True
                     if is_first_iter is False:
                         is_first_iter = True
                     else:

--- a/prolog/repl.py
+++ b/prolog/repl.py
@@ -101,6 +101,8 @@ def run_repl(runtime):
                 if has_solution:
                     print('yes')
                 else:
+                    if not is_first_iter:
+                        print(runtime.stream_read(), end='')
                     print('no')
             except IndexError:
                 print('Unterminated input')

--- a/prolog/repl.py
+++ b/prolog/repl.py
@@ -9,6 +9,7 @@ from .parser import Parser
 from .scanner import Scanner
 from .interpreter import Variable, Rule
 from .errors import InterpreterError
+from .types import FALSE
 
 
 init(autoreset=True)
@@ -48,7 +49,8 @@ def warning(input):
     return f'{Fore.YELLOW}{input}'
 
 
-def display_variables(goal, solution):
+def display_variables(goal, solution, stream_reader):
+    print(stream_reader(), end='')
     has_variables = False
     if isinstance(goal, Rule):
         goal = goal.head
@@ -84,8 +86,7 @@ def run_repl(runtime):
                 is_first_iter = False
                 has_solution = False
                 for solution in runtime.execute(goal):
-                    print(f'sol: {solution}')
-                    if solution is not None:
+                    if not isinstance(solution, FALSE):
                         has_solution = True
                     if is_first_iter is False:
                         is_first_iter = True
@@ -96,7 +97,7 @@ def run_repl(runtime):
                         else:
                             has_solution = False
                             break
-                    display_variables(goal, solution)
+                    display_variables(goal, solution, runtime.stream_read)
                 if has_solution:
                     print('yes')
                 else:

--- a/tests/data/myadven.prolog
+++ b/tests/data/myadven.prolog
@@ -57,3 +57,16 @@ look :-
     list_things(Place),
     write('You can go to:'), nl,
     list_connections(Place).
+
+goto(Place) :-
+    can_go(Place),
+    % move(Place),
+    look.
+
+can_go(Place) :-
+    here(X),
+    connect(X, Place).
+can_go(_) :-
+    write('You cannot get there from here.'),
+    nl,
+    fail.

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -222,9 +222,11 @@ def test_fail_builtin():
 
     has_solution = False
     for index, item in enumerate(runtime.execute(goal)):
-        has_solution = True
-        assert str(goal.head.match(item).get(X)) == \
-            expected_binding[index]['X']
+        print(f'item: {item}')
+        if item is not None:
+            has_solution = True
+            assert str(goal.head.match(item).get(X)) == \
+                expected_binding[index]['X']
 
     assert has_solution is False
 
@@ -579,7 +581,7 @@ def test_logic_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len(list(runtime.execute(goal))))
+    assert(len([s for s in runtime.execute(goal) if s]))
 
     goal_text = "sum_eq_4(3)."
 
@@ -587,7 +589,7 @@ def test_logic_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(not(len(list(runtime.execute(goal)))))
+    assert(not(len([s for s in runtime.execute(goal) if s])))
 
 
 def test_logic_not_equal():
@@ -607,7 +609,7 @@ def test_logic_not_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len(list(runtime.execute(goal))))
+    assert(len([s for s in runtime.execute(goal)if s]))
 
     goal_text = "sum_eq_4(2)."
 
@@ -615,7 +617,7 @@ def test_logic_not_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(not(len(list(runtime.execute(goal)))))
+    assert(not(len([s for s in runtime.execute(goal) if s])))
 
 
 def test_logic_greater():
@@ -635,7 +637,7 @@ def test_logic_greater():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len(list(runtime.execute(goal))))
+    assert(len([s for s in runtime.execute(goal) if s]))
 
     goal_text = "sum_4(2)."
 
@@ -643,7 +645,7 @@ def test_logic_greater():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(not(len(list(runtime.execute(goal)))))
+    assert(not(len([s for s in runtime.execute(goal) if s])))
 
 
 def test_logic_greater_or_equal():
@@ -663,7 +665,7 @@ def test_logic_greater_or_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len(list(runtime.execute(goal))))
+    assert(len([s for s in runtime.execute(goal) if s]))
 
     goal_text = "sum_4(2)."
 
@@ -671,7 +673,7 @@ def test_logic_greater_or_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len(list(runtime.execute(goal))))
+    assert(len([s for s in runtime.execute(goal) if s]))
 
     goal_text = "sum_4(1)."
 
@@ -679,7 +681,7 @@ def test_logic_greater_or_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(not(len(list(runtime.execute(goal)))))
+    assert(not(len([s for s in runtime.execute(goal) if s])))
 
 
 def test_logic_less():
@@ -699,7 +701,7 @@ def test_logic_less():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len(list(runtime.execute(goal))))
+    assert(len([s for s in runtime.execute(goal) if s]))
 
     goal_text = "sum_4(2)."
 
@@ -707,7 +709,7 @@ def test_logic_less():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(not(len(list(runtime.execute(goal)))))
+    assert(not(len([s for s in runtime.execute(goal) if s])))
 
 
 def test_logic_less_or_equal():
@@ -727,7 +729,7 @@ def test_logic_less_or_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len(list(runtime.execute(goal))))
+    assert(len([s for s in runtime.execute(goal) if s]))
 
     goal_text = "sum_4(2)."
 
@@ -735,7 +737,7 @@ def test_logic_less_or_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len(list(runtime.execute(goal))))
+    assert(len([s for s in runtime.execute(goal) if s]))
 
     goal_text = "sum_4(3)."
 
@@ -743,4 +745,4 @@ def test_logic_less_or_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(not(len(list(runtime.execute(goal)))))
+    assert(not(len([s for s in runtime.execute(goal) if s])))

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1,5 +1,5 @@
 from prolog.interpreter import Runtime
-from prolog.types import Variable, Term
+from prolog.types import Variable, Term, FALSE
 from prolog.parser import Parser
 from prolog.scanner import Scanner
 import cProfile
@@ -223,7 +223,7 @@ def test_fail_builtin():
     has_solution = False
     for index, item in enumerate(runtime.execute(goal)):
         print(f'item: {item}')
-        if item is not None:
+        if not isinstance(item, FALSE):
             has_solution = True
             assert str(goal.head.match(item).get(X)) == \
                 expected_binding[index]['X']
@@ -581,7 +581,8 @@ def test_logic_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len([s for s in runtime.execute(goal) if s]))
+    assert(
+        len([s for s in runtime.execute(goal) if not isinstance(s, FALSE)]))  # noqa
 
     goal_text = "sum_eq_4(3)."
 
@@ -589,7 +590,8 @@ def test_logic_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(not(len([s for s in runtime.execute(goal) if s])))
+    assert(
+        not(len([s for s in runtime.execute(goal) if not isinstance(s, FALSE)])))  # noqa
 
 
 def test_logic_not_equal():
@@ -609,7 +611,7 @@ def test_logic_not_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len([s for s in runtime.execute(goal)if s]))
+    assert(len([s for s in runtime.execute(goal)if not isinstance(s, FALSE)]))  # noqa
 
     goal_text = "sum_eq_4(2)."
 
@@ -617,7 +619,7 @@ def test_logic_not_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(not(len([s for s in runtime.execute(goal) if s])))
+    assert(not(len([s for s in runtime.execute(goal) if not isinstance(s, FALSE)])))  # noqa
 
 
 def test_logic_greater():
@@ -637,7 +639,7 @@ def test_logic_greater():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len([s for s in runtime.execute(goal) if s]))
+    assert(len([s for s in runtime.execute(goal) if not isinstance(s, FALSE)]))  # noqa
 
     goal_text = "sum_4(2)."
 
@@ -645,7 +647,7 @@ def test_logic_greater():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(not(len([s for s in runtime.execute(goal) if s])))
+    assert(not(len([s for s in runtime.execute(goal) if not isinstance(s, FALSE)])))  # noqa
 
 
 def test_logic_greater_or_equal():
@@ -665,7 +667,7 @@ def test_logic_greater_or_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len([s for s in runtime.execute(goal) if s]))
+    assert(len([s for s in runtime.execute(goal) if not isinstance(s, FALSE)]))  # noqa
 
     goal_text = "sum_4(2)."
 
@@ -673,7 +675,7 @@ def test_logic_greater_or_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len([s for s in runtime.execute(goal) if s]))
+    assert(len([s for s in runtime.execute(goal) if not isinstance(s, FALSE)]))  # noqa
 
     goal_text = "sum_4(1)."
 
@@ -681,7 +683,7 @@ def test_logic_greater_or_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(not(len([s for s in runtime.execute(goal) if s])))
+    assert(not(len([s for s in runtime.execute(goal) if not isinstance(s, FALSE)])))  # noqa
 
 
 def test_logic_less():
@@ -701,7 +703,7 @@ def test_logic_less():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len([s for s in runtime.execute(goal) if s]))
+    assert(len([s for s in runtime.execute(goal) if not isinstance(s, FALSE)]))  # noqa
 
     goal_text = "sum_4(2)."
 
@@ -709,7 +711,7 @@ def test_logic_less():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(not(len([s for s in runtime.execute(goal) if s])))
+    assert(not(len([s for s in runtime.execute(goal) if not isinstance(s, FALSE)])))  # noqa
 
 
 def test_logic_less_or_equal():
@@ -729,7 +731,7 @@ def test_logic_less_or_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len([s for s in runtime.execute(goal) if s]))
+    assert(len([s for s in runtime.execute(goal) if not isinstance(s, FALSE)]))  # noqa
 
     goal_text = "sum_4(2)."
 
@@ -737,7 +739,7 @@ def test_logic_less_or_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(len([s for s in runtime.execute(goal) if s]))
+    assert(len([s for s in runtime.execute(goal) if not isinstance(s, FALSE)]))  # noqa
 
     goal_text = "sum_4(3)."
 
@@ -745,4 +747,4 @@ def test_logic_less_or_equal():
         Scanner(goal_text).tokenize()
     ).parse_query()
 
-    assert(not(len([s for s in runtime.execute(goal) if s])))
+    assert(not(len([s for s in runtime.execute(goal) if not isinstance(s, FALSE)])))  # noqa


### PR DESCRIPTION
Currently built in commands like write, nl, tab write directly to stdout.  Since PyProlog can be used as library it should be up to client how to handle io.  This update makes change to write to internal stream inside of Runtime (StringIO).  REPL was also updated to use this new stream and print the output to stdout.