### PR TITLE
Implement Cut

### DIFF
--- a/prolog/builtins.py
+++ b/prolog/builtins.py
@@ -37,6 +37,23 @@ class Fail:
         return str(self)
 
 
+class Cut:
+    def __init__(self):
+        self.name = 'cut'
+
+    def match(self, other):
+        return {}
+
+    def substitute(self, bindings):
+        return self
+
+    def __str__(self):
+        return str(self.name)
+
+    def __repr__(self):
+        return str(self)
+
+
 class Write(BuiltinsBase):
     def __init__(self, *args):
         self.pred = 'write'

--- a/prolog/parser.py
+++ b/prolog/parser.py
@@ -1,7 +1,7 @@
 from prolog.token_type import TokenType
 from .interpreter import Conjunction, Rule
 from .types import Arithmetic, Logic, Variable, Term, TRUE, Number
-from .builtins import Fail, Write, Nl, Tab, Retract, AssertA, AssertZ
+from .builtins import Fail, Write, Nl, Tab, Retract, AssertA, AssertZ, Cut
 from .expression import BinaryExpression, PrimaryExpression
 
 
@@ -171,6 +171,7 @@ class Parser:
             TokenType.RETRACT,
             TokenType.ASSERTA,
             TokenType.ASSERTZ,
+            TokenType.CUT,
             TokenType.ATOM
         ]):
             self._report(token.line, f'Bad atom name: {token.lexeme}')
@@ -242,6 +243,9 @@ class Parser:
 
         if self._is_type(token, TokenType.FAIL):
             return Fail()
+
+        if self._is_type(token, TokenType.CUT):
+            return Cut()
 
         if self._is_type(token, TokenType.NL):
             return Nl()

--- a/prolog/repl.py
+++ b/prolog/repl.py
@@ -9,7 +9,7 @@ from .parser import Parser
 from .scanner import Scanner
 from .interpreter import Variable, Rule
 from .errors import InterpreterError, ScannerError
-from .types import FALSE
+from .types import FALSE, CUT
 
 
 init(autoreset=True)
@@ -90,6 +90,8 @@ def run_repl(runtime):
                 is_first_iter = False
                 has_solution = False
                 for solution in runtime.execute(goal):
+                    if isinstance(solution, CUT):
+                        break
                     if not isinstance(solution, FALSE):
                         has_solution = True
                     if is_first_iter is False:

--- a/prolog/repl.py
+++ b/prolog/repl.py
@@ -57,9 +57,11 @@ def display_variables(goal, solution, stream_reader):
     for index, arg in enumerate(goal.args):
         if isinstance(arg, Variable):
             v = goal.args[index]
-            bind = goal.match(solution).get(v)
-            print(success(f'{arg} = {bind}'), end=' ')
-            has_variables = True
+            goal_match = goal.match(solution)
+            if goal_match:
+                bind = goal_match.get(v)
+                print(success(f'{arg} = {bind}'), end=' ')
+                has_variables = True
     if has_variables:
         print('')
 

--- a/prolog/scanner.py
+++ b/prolog/scanner.py
@@ -179,6 +179,8 @@ class Scanner:
             self._process_number()
         elif self._is_digit(c):
             self._process_number()
+        elif c == '!':
+            self._add_token(TokenType.CUT)
         elif c == '(':
             self._add_token(TokenType.LEFTPAREN)
         elif c == ')':

--- a/prolog/token_type.py
+++ b/prolog/token_type.py
@@ -30,4 +30,5 @@ class TokenType(Enum):
     RETRACT = auto(),
     ASSERTA = auto(),
     ASSERTZ = auto(),
+    CUT = auto(),
     EOF = auto()

--- a/prolog/types.py
+++ b/prolog/types.py
@@ -221,6 +221,17 @@ class FALSE(Term):
         yield self
 
 
+class CUT(Term):
+    def __init__(self):
+        super().__init__(CUT)
+
+    def substitute(self, bindings):
+        return {}
+
+    def query(self, runtime):
+        yield self
+
+
 class ExpressionBinder(Visitor):
     """Binds variables.
 

--- a/tests/data/test.prolog
+++ b/tests/data/test.prolog
@@ -18,3 +18,17 @@ freezing(X) :- X =< 32.
 sum_greater_4(Y) :- X is Y + 3, X > 4.
 sum_less_4 :- X is 1 + 1, X < 4.
 sum_greater_eq_4 :- X is 2 + 2, X >= 4.
+
+data(one).
+data(two).
+data(three).
+
+cut_test_a(X) :-
+    data(X).
+cut_test_a('last clause').
+
+test_cut(X) :-
+    cut_test_a(X),
+    write(X),
+    nl,
+    fail.

--- a/tests/data/test.prolog
+++ b/tests/data/test.prolog
@@ -32,3 +32,14 @@ test_cut(X) :-
     write(X),
     nl,
     fail.
+
+cut_test_b(X) :-
+    data(X),
+    !.
+cut_test_b('last clause').
+
+test_cut_b(X) :-
+    cut_test_b(X),
+    write(X),
+    nl,
+    fail.

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1040,6 +1040,7 @@ def test_assertz_rule():
         assert str(item) == expected_results[index]
         assert str(goal.match(item).get(x)) == expected_bindings[index]
 
+
 def test_cut_predicate():
     input = '''
     data(one).
@@ -1049,7 +1050,7 @@ def test_cut_predicate():
     cut_test_a(X) :-
     data(X).
     cut_test_a('last clause').
-    
+
     cut_test_b(X) :-
     data(X),
     !.

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1,5 +1,5 @@
 from prolog.interpreter import Runtime, Rule
-from prolog.types import Variable, Term, FALSE, TRUE
+from prolog.types import Variable, Term, FALSE, TRUE, CUT
 from prolog.parser import Parser
 from prolog.scanner import Scanner
 import cProfile
@@ -1039,3 +1039,78 @@ def test_assertz_rule():
     for index, item in enumerate(runtime.execute(goal)):
         assert str(item) == expected_results[index]
         assert str(goal.match(item).get(x)) == expected_bindings[index]
+
+def test_cut_predicate():
+    input = '''
+    data(one).
+    data(two).
+    data(three).
+
+    cut_test_a(X) :-
+    data(X).
+    cut_test_a('last clause').
+    
+    cut_test_b(X) :-
+    data(X),
+    !.
+    cut_test_b('last clause').
+    '''
+
+    rules = Parser(
+        Scanner(input).tokenize()
+    ).parse_rules()
+
+    runtime = Runtime(rules)
+
+    goal_text = "cut_test_a(X)."
+    goal = Parser(
+        Scanner(goal_text).tokenize()
+    ).parse_query()
+    assert(list(runtime.execute(goal)))
+
+    x = goal.args[0]
+
+    expected_results = [
+        'cut_test_a(one)',
+        'cut_test_a(two)',
+        'cut_test_a(three)',
+        'cut_test_a(last clause)'
+    ]
+
+    expected_bindings = [
+        'one',
+        'two',
+        'three',
+        'last clause'
+    ]
+
+    for index, item in enumerate(runtime.execute(goal)):
+        assert str(item) == expected_results[index]
+        assert str(goal.match(item).get(x)) == expected_bindings[index]
+
+    goal_text = "cut_test_b(X)."
+    goal = Parser(
+        Scanner(goal_text).tokenize()
+    ).parse_query()
+
+    assert(list(runtime.execute(goal)))
+
+    goal_text = "cut_test_b(X)."
+
+    goal = Parser(
+        Scanner(goal_text).tokenize()
+    ).parse_query()
+
+    x = goal.args[0]
+
+    expected_results = ['cut_test_b(one)']
+
+    expected_bindings = ['one']
+
+    for index, item in enumerate(runtime.execute(goal)):
+        if not isinstance(item, CUT):
+            print(f'ITEM: {item}')
+            print(f'{item} == {expected_results[index]}')
+            print(f'{goal.match(item).get(x)} == {expected_bindings[index]}')
+            assert str(item) == expected_results[index]
+            assert str(goal.match(item).get(x)) == expected_bindings[index]


### PR DESCRIPTION
# Implements **cut** predicate.

The cut effectively tells Prolog to freeze all the decisions made so far in this predicate.  That is, if required to backtrack, it will automatically fail without trying other alternatives.

## Example, behavior without cut:

```
cut_test_a(X) :-
    data(X).
cut_test_a('last clause').

test_cut(X) :-
    cut_test_a(X),
    write(X),
    nl,
    fail.
```

From REPL:

```
Welcome to Simple Prolog
ctrl-c to quit
> test_cut(X).
one
two
three
last clause
no
>
```

# Example with cut:

```
cut_test_a(X) :-
    data(X),
    !.
cut_test_a('last clause').

test_cut(X) :-
    cut_test_a(X),
    write(X),
    nl,
    fail.
```

From REPL:

```
Welcome to Simple Prolog
ctrl-c to quit
> test_cut(X).
one
no
>
```


# Bug fixes:
- Fixed bug where REPL crashes when it detects None match.

Closes #13 