### PR TITLE
Support for lists

### DIFF
--- a/prolog/types.py
+++ b/prolog/types.py
@@ -46,11 +46,39 @@ class List:
         return reduce(merge_bindings, [{}] + m)
 
     def match(self, other):
-        if isinstance(self.lst, Variable) and \
-           isinstance(other, List):
+        '''
+        list                 tail
+        ---------------------------------------
+        list                None
+        list                Variable
+        list                List
+        Variable            None
+        Variable            Variable
+        Variable            List
+        '''
+        if not isinstance(other, List):
+            return {}
+
+        if isinstance(self.lst, list) and \
+           len(other.lst) >= len(self.lst):
+            if isinstance(self.tail, Variable):
+                left_lst = other.lst[:len(self.lst)]
+                right_lst = other.lst[len(self.lst):]
+                bindings = self._match_lsts(self.lst, left_lst)
+                bindings[self.tail] = List(right_lst)
+                return bindings
+            elif isinstance(self.tail, List):
+                left_lst = other.lst[:1]
+                right_lst = other.lst[1:]
+                bindings_lst = self._match_lsts(self.lst, left_lst)
+                bindings_tail = self._match_lsts(self.tail.lst, right_lst)
+                return merge_bindings(bindings_lst, bindings_tail)
+            elif self.tail is None and len(self.lst) == len(other.lst):
+                return self._match_lsts(self.lst, other.lst)
+        elif isinstance(self.lst, Variable):
             if len(other.lst) == 0:
                 return {}
-            if self.tail and isinstance(self.tail, Variable):
+            if isinstance(self.tail, Variable):
                 left_lst = other.lst[:1]
                 right_lst = other.lst[1:]
                 bindings = {
@@ -58,25 +86,14 @@ class List:
                     self.tail: List(right_lst)
                 }
                 return bindings
-            elif self.tail and isinstance(self.tail, List):
-                pass
-        elif isinstance(self.lst, list):
-            if isinstance(other, List) and \
-               len(self.lst) == len(other.lst) and \
-               not self.tail:  # simple lists with no tail, must match len
-                return self._match_lsts(self.lst, other.lst)
-            elif isinstance(other, List) and self.tail:
-                # case when bar is used
-                if isinstance(self.tail, Variable) and \
-                   len(other.lst) >= len(self.lst):  # tail can be variable
-                    left_lst = other.lst[:len(self.lst)]
-                    right_lst = other.lst[len(self.lst):]
-                    bindings = self._match_lsts(self.lst, left_lst)
-                    bindings[self.tail] = List(right_lst)
-                    return bindings
-                elif isinstance(self.tail, List):  # or another list
-                    left_lst = other.lst[:len(self.lst)]
-                    right_lst = other.lst[len(self.lst):]
+            elif isinstance(self.tail, List):
+                left_lst = other.lst[:1]
+                right_lst = other.lst[1:]
+                bindings_lst = {
+                    self.lst: left_lst[0]
+                }
+                bindings_tail = self._match_lsts(self.tail.lst, right_lst)
+                return merge_bindings(bindings_lst, bindings_tail)
 
         return {}
 

--- a/prolog/types.py
+++ b/prolog/types.py
@@ -28,6 +28,67 @@ class Variable:
         return str(self)
 
 
+class List:
+    def __init__(self, lst, tail=None):
+        self.name = 'list'
+        self.lst = lst
+        self.tail = tail
+
+    def _match_lsts(self, lst1, lst2):
+        m = list(
+                map(
+                    (lambda arg1, arg2: arg1.match(arg2)),
+                    lst1,
+                    lst2
+                )
+        )
+
+        return reduce(merge_bindings, [{}] + m)
+
+    def match(self, other):
+        if isinstance(other, List) and \
+           len(self.lst) == len(other.lst) and \
+           not self.tail:
+            # if both list contain same number of elements and
+            # each elements is a match
+            # m = list(
+            #         map(
+            #             (lambda arg1, arg2: arg1.match(arg2)),
+            #             self.lst,
+            #             other.lst
+            #         )
+            # )
+
+            # return reduce(merge_bindings, [{}] + m)
+            return self._match_lsts(self.lst, other.lst)
+        elif isinstance(other, List) and self.tail:  # case when bar is used
+            if isinstance(self.tail, Variable) and \
+               len(other.lst) >= len(self.lst):  # tail can be variable
+                left_lst = other.lst[:len(self.lst)]
+                right_lst = other[len(self.lst):]
+                bindings = self._match_lsts(self.lst, left_lst)
+                bindings[self.tail] = right_lst
+            elif isinstance(self.tail, List):  # or another list
+                pass
+
+        return None
+
+    def substitute(self, bindings):
+        return List(map(
+            (lambda arg: arg.substitute(bindings)),
+            self.lst
+        ))
+
+    def query(self, runtime):
+        yield from runtime.execute(self)
+    
+    def __str__(self):
+        return f'[{", ".join(map(str, self.lst))}]'
+
+    def __repr__(self):
+        return str(self)
+
+
 class Term:
     def __init__(self, pred, *args):
         self.pred = pred

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -14,6 +14,7 @@ def test_list_with_simple_terms():
     m = l1.match(l2)
     assert(m == {})
 
+
 def test_list_with_vars_and_terms():
     a1_1 = Variable('X')
     a1_2 = Variable('Y')
@@ -30,6 +31,7 @@ def test_list_with_vars_and_terms():
     sub = l1.substitute(m)
     assert(str(sub) == '[a1, a2]')
 
+
 def test_list_with_subset_vars():
     a1_1 = Variable('X')
     a1_2 = Term('a2')
@@ -45,3 +47,59 @@ def test_list_with_subset_vars():
 
     sub = l1.substitute(m)
     assert(str(sub) == '[a1, a2]')
+
+
+def test_list_with_bar_variable_tail():
+    a1_1 = Term('a1')
+    a1_2 = Term('a2')
+    bar_tail = Variable('X')
+
+    a2_1 = Term('a1')
+    a2_2 = Term('a2')
+    a2_3 = Term('a3')
+
+    l1 = List([a1_1, a1_2], bar_tail)
+    l2 = List([a2_1, a2_2, a2_3])
+
+    m = l1.match(l2)
+    assert(str(m) == '{X: [a3]}')
+
+    sub = l1.substitute(m)
+    assert(str(sub) == '[a1, a2 | [a3]]')
+
+
+def test_list_with_lst_vars_and_tail_vars():
+    a1_1 = Variable('X')
+    a1_2 = Variable('Y')
+    bar_tail = Variable('T')
+
+    a2_1 = Term('a1')
+    a2_2 = Term('a2')
+    a2_3 = Term('a3')
+
+    l1 = List([a1_1, a1_2], bar_tail)
+    l2 = List([a2_1, a2_2, a2_3])
+
+    m = l1.match(l2)
+    assert(str(m) == '{X: a1, Y: a2, T: [a3]}')
+
+    sub = l1.substitute(m)
+    assert(str(sub) == '[a1, a2 | [a3]]')
+
+
+def test_list_with_head_and_tail_vars():
+    head_var = Variable('H')
+    bar_tail = Variable('T')
+
+    a2_1 = Term('a1')
+    a2_2 = Term('a2')
+    a2_3 = Term('a3')
+
+    l1 = List(head_var, bar_tail)
+    l2 = List([a2_1, a2_2, a2_3])
+
+    m = l1.match(l2)
+    assert(str(m) == '{H: a1, T: [a2, a3]}')
+
+    sub = l1.substitute(m)
+    assert(str(sub) == '[a1 | [a2, a3]]')

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,0 +1,47 @@
+from prolog.types import List, Term, Variable
+
+
+def test_list_with_simple_terms():
+    a1_1 = Term('a1')
+    a1_2 = Term('a2')
+
+    a2_1 = Term('a1')
+    a2_2 = Term('a2')
+
+    l1 = List([a1_1, a1_2])
+    l2 = List([a2_1, a2_2])
+
+    m = l1.match(l2)
+    assert(m == {})
+
+def test_list_with_vars_and_terms():
+    a1_1 = Variable('X')
+    a1_2 = Variable('Y')
+
+    a2_1 = Term('a1')
+    a2_2 = Term('a2')
+
+    l1 = List([a1_1, a1_2])
+    l2 = List([a2_1, a2_2])
+
+    m = l1.match(l2)
+    assert(str(m) == '{X: a1, Y: a2}')
+
+    sub = l1.substitute(m)
+    assert(str(sub) == '[a1, a2]')
+
+def test_list_with_subset_vars():
+    a1_1 = Variable('X')
+    a1_2 = Term('a2')
+
+    a2_1 = Term('a1')
+    a2_2 = Term('a2')
+
+    l1 = List([a1_1, a1_2])
+    l2 = List([a2_1, a2_2])
+
+    m = l1.match(l2)
+    assert(str(m) == '{X: a1}')
+
+    sub = l1.substitute(m)
+    assert(str(sub) == '[a1, a2]')

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -103,3 +103,22 @@ def test_list_with_head_and_tail_vars():
 
     sub = l1.substitute(m)
     assert(str(sub) == '[a1 | [a2, a3]]')
+
+
+def test_list_with_head_var_and_tail_list():
+    head_var = Variable('H')
+    tail1 = Variable('X')
+    tail2 = Variable('Y')
+
+    a2_1 = Term('a1')
+    a2_2 = Term('a2')
+    a2_3 = Term('a3')
+
+    l1 = List(head_var, List([tail1, tail2]))
+    l2 = List([a2_1, a2_2, a2_3])
+
+    m = l1.match(l2)
+    assert(str(m) == '{H: a1, X: a2, Y: a3}')
+
+    sub = l1.substitute(m)
+    assert(str(sub) == '[a1 | [a2, a3]]')


### PR DESCRIPTION
Lists are collection of terms.  Terms can be any Prolog data types, including structures or other lists.  Syntactically, a list is denoted by square brackets with the terms separated by commas.  For example,

```
[apple, brocolli, orange]
```

Lists can match in the following ways:

```
- [a1, a2, a3] = [a1, a2, a3]  ==> [a1, a2, a3]
- [X, Y] = [a1, a2]   ==> [a1, a2]
- [X, a2] = [a1, a2]  ==> [a1, a2]
- [a1, a2, a3] = [a1, a2 | H]  ==> [a1, a2, [a3]]
- [a1, a2, a3] = [H | T]  ==> [a1, [a2, a3]]
- [a1, a2, a3] = [H | [X, Y]]  ==> [a1, [a2, a3]]
```

Closes #12 